### PR TITLE
Fix menu assign ids

### DIFF
--- a/lib/menu/server.ex
+++ b/lib/menu/server.ex
@@ -333,7 +333,7 @@ defmodule ExSni.Menu.Server do
          state
          |> set_current_menu(menu)
          |> set_menu_queue([])
-         |> queue_items_properties_updated_signal(updates)
+         |> trigger_items_properties_updated_signal(updates)
          |> trigger_layout_update_signal()}
     end
   end

--- a/lib/menu/server.ex
+++ b/lib/menu/server.ex
@@ -276,7 +276,14 @@ defmodule ExSni.Menu.Server do
            menu_queue: [%Menu{root: new_root} = new_menu]
          } = state
        ) do
-    case MenuDiff.diff(new_root, old_root) do
+    IO.inspect(old_root, label: "[MENU DIFF] old root", limit: :infinity)
+    IO.inspect(new_root, label: "[MENU DIFF] new root", limit: :infinity)
+
+    menu_diff =
+      MenuDiff.diff(new_root, old_root)
+      |> IO.inspect(label: "[MENU DIFF] result")
+
+    case menu_diff do
       {-1, [], _} ->
         # No changes between the menus.
         menu = %{new_menu | version: old_version}
@@ -400,6 +407,8 @@ defmodule ExSni.Menu.Server do
   end
 
   defp service_send_signal(service_pid, signal, args) do
+    IO.inspect([signal, args], label: "Sending D-Bus signal", limit: :infinity)
+
     ExDBus.Service.send_signal(
       service_pid,
       "/MenuBar",
@@ -474,19 +483,22 @@ defmodule ExSni.Menu.Server do
   end
 
   defp method_reply("GetLayout", {parentId, depth, properties}, menu) do
-    # IO.inspect({parentId, depth, properties},
-    #   label: "[#{System.os_time(:millisecond)}] [ExSni][Menu.Server] GetLayout"
-    # )
+    IO.inspect({parentId, depth, properties},
+      label: "[#{System.os_time(:millisecond)}] [ExSni][Menu.Server] GetLayout"
+    )
 
     Menu.get_layout(menu, parentId, depth, properties)
+    |> IO.inspect(label: "GetLayout reply", limit: :infinity)
   end
 
   defp method_reply("GetGroupProperties", {ids, properties}, menu) do
-    # IO.inspect({ids, properties},
-    #   label: "[#{System.os_time(:millisecond)}] [ExSni][Menu.Server] GetGroupProperties"
-    # )
+    IO.inspect({ids, properties},
+      label: "[#{System.os_time(:millisecond)}] [ExSni][Menu.Server] GetGroupProperties"
+    )
 
-    result = Menu.get_group_properties(menu, ids, properties)
+    result =
+      Menu.get_group_properties(menu, ids, properties)
+      |> IO.inspect(label: "GetGroupProperties reply", limit: :infinity)
 
     {:ok, [{:array, {:struct, [:int32, {:dict, :string, :variant}]}}], [result]}
   end
@@ -669,10 +681,12 @@ defmodule ExSni.Menu.Server do
   end
 
   defp set_current_menu(state, menu) do
+    IO.inspect(menu, label: "Set current menu", limit: :infinity)
     %{state | menu: menu}
   end
 
   defp set_menu_queue(state, queue) do
+    IO.inspect(queue, label: "Set menu queue", limit: :infinity)
     %{state | menu_queue: queue}
   end
 

--- a/lib/menu_diff.ex
+++ b/lib/menu_diff.ex
@@ -11,7 +11,7 @@ defmodule ExSni.MenuDiff do
 
     case {inserts, deletes, updates, nops} do
       {[], [], [], []} ->
-        IO.inspect("{[], [], [], []}", label: "[DIFF::[1]]")
+        # IO.inspect("{[], [], [], []}", label: "[DIFF::[1]]")
         # [x] Implemented
         # Nothing to update. Both new and old menus are empty
         # No layout changes
@@ -19,7 +19,7 @@ defmodule ExSni.MenuDiff do
         {-1, [], old_root}
 
       {[], [], [], _unchanged} ->
-        IO.inspect("{[], [], [], _unchanged}", label: "[DIFF::[2]]")
+        # IO.inspect("{[], [], [], _unchanged}", label: "[DIFF::[2]]")
         # [x] Implemented
         # Nothing to update. Both menus are equal
         # No layout changes
@@ -27,7 +27,7 @@ defmodule ExSni.MenuDiff do
         {-1, [], old_root}
 
       {_inserts, _deletes, [], []} ->
-        IO.inspect("{_inserts, _deletes, [], []}", label: "[DIFF::[3]]")
+        # IO.inspect("{_inserts, _deletes, [], []}", label: "[DIFF::[3]]")
         # [x] Implemented
         # If there are inserts or deletes, but there are no updates and no unchanged
         # then this is a completely different new menu
@@ -41,7 +41,7 @@ defmodule ExSni.MenuDiff do
         {-2, [], node}
 
       {[], [], updates, []} ->
-        IO.inspect("{[], [], updates, []}", label: "[DIFF::[4]]")
+        # IO.inspect("{[], [], updates, []}", label: "[DIFF::[4]]")
         # [x] Implemented
         # All items in the old menu have changes.
         # Return the new menu, but assign old menu IDs to all the new items
@@ -60,7 +60,7 @@ defmodule ExSni.MenuDiff do
         {-1, group_properties, node}
 
       {[], [], updates, _unchanged} ->
-        IO.inspect("{[], [], updates, _unchanged}", label: "[DIFF::[5]]")
+        # IO.inspect("{[], [], updates, _unchanged}", label: "[DIFF::[5]]")
         # [x] Implemented
         # This is a partial update of the menu.
         # Return the new menu, and copy old menu IDs to the updated items
@@ -81,7 +81,7 @@ defmodule ExSni.MenuDiff do
         {-1, group_properties, node}
 
       {_inserts, deletes, updates, []} ->
-        IO.inspect("{inserts, deletes, updates, []}", label: "[DIFF::[6]]")
+        # IO.inspect("{inserts, deletes, updates, []}", label: "[DIFF::[6]]")
         # [x] Implemented
         # This is updates to all items in the menu and some deletes and/or some inserts
         # Some layout changes
@@ -113,7 +113,7 @@ defmodule ExSni.MenuDiff do
         {0, group_properties, node}
 
       {_inserts, deletes, [], _unchanged} ->
-        IO.inspect("{inserts, deletes, [], unchanged}", label: "[DIFF::[7]]")
+        # IO.inspect("{inserts, deletes, [], unchanged}", label: "[DIFF::[7]]")
         # [x] Implemented
         # This is only a layout change where items have been removed from the old menu
         # or added in the new menu.
@@ -139,7 +139,7 @@ defmodule ExSni.MenuDiff do
         {0, [], node}
 
       {_inserts, deletes, updates, _unchanged} ->
-        IO.inspect("{inserts, deletes, updates, unchanged}", label: "[DIFF::[8]]")
+        # IO.inspect("{inserts, deletes, updates, unchanged}", label: "[DIFF::[8]]")
         # [x] Implemented
         # There are mixed changes in our menus:
         #   inserts and/or deletes, updates but also unchanged items
@@ -234,6 +234,7 @@ defmodule ExSni.MenuDiff do
     {id, last_id, new_ids_map} =
       case Map.get(mapping, node) do
         %{id: id} when not is_nil(id) ->
+          last_id = if id >= last_id, do: id + 1, else: last_id
           {id, last_id, new_ids_map}
 
         _ ->

--- a/lib/menu_diff.ex
+++ b/lib/menu_diff.ex
@@ -11,7 +11,7 @@ defmodule ExSni.MenuDiff do
 
     case {inserts, deletes, updates, nops} do
       {[], [], [], []} ->
-        # IO.inspect("{[], [], [], []}", label: "[DIFF::[1]]")
+        IO.inspect("{[], [], [], []}", label: "[DIFF::[1]]")
         # [x] Implemented
         # Nothing to update. Both new and old menus are empty
         # No layout changes
@@ -19,7 +19,7 @@ defmodule ExSni.MenuDiff do
         {-1, [], old_root}
 
       {[], [], [], _unchanged} ->
-        # IO.inspect("{[], [], [], _unchanged}", label: "[DIFF::[2]]")
+        IO.inspect("{[], [], [], _unchanged}", label: "[DIFF::[2]]")
         # [x] Implemented
         # Nothing to update. Both menus are equal
         # No layout changes
@@ -27,7 +27,7 @@ defmodule ExSni.MenuDiff do
         {-1, [], old_root}
 
       {_inserts, _deletes, [], []} ->
-        # IO.inspect("{_inserts, _deletes, [], []}", label: "[DIFF::[3]]")
+        IO.inspect("{_inserts, _deletes, [], []}", label: "[DIFF::[3]]")
         # [x] Implemented
         # If there are inserts or deletes, but there are no updates and no unchanged
         # then this is a completely different new menu
@@ -41,7 +41,7 @@ defmodule ExSni.MenuDiff do
         {-2, [], node}
 
       {[], [], updates, []} ->
-        # IO.inspect("{[], [], updates, []}", label: "[DIFF::[4]]")
+        IO.inspect("{[], [], updates, []}", label: "[DIFF::[4]]")
         # [x] Implemented
         # All items in the old menu have changes.
         # Return the new menu, but assign old menu IDs to all the new items
@@ -60,7 +60,7 @@ defmodule ExSni.MenuDiff do
         {-1, group_properties, node}
 
       {[], [], updates, _unchanged} ->
-        # IO.inspect("{[], [], updates, _unchanged}", label: "[DIFF::[5]]")
+        IO.inspect("{[], [], updates, _unchanged}", label: "[DIFF::[5]]")
         # [x] Implemented
         # This is a partial update of the menu.
         # Return the new menu, and copy old menu IDs to the updated items
@@ -81,7 +81,7 @@ defmodule ExSni.MenuDiff do
         {-1, group_properties, node}
 
       {_inserts, deletes, updates, []} ->
-        # IO.inspect("{inserts, deletes, updates, []}", label: "[DIFF::[6]]")
+        IO.inspect("{inserts, deletes, updates, []}", label: "[DIFF::[6]]")
         # [x] Implemented
         # This is updates to all items in the menu and some deletes and/or some inserts
         # Some layout changes
@@ -113,7 +113,7 @@ defmodule ExSni.MenuDiff do
         {0, group_properties, node}
 
       {_inserts, deletes, [], _unchanged} ->
-        # IO.inspect("{inserts, deletes, [], unchanged}", label: "[DIFF::[7]]")
+        IO.inspect("{inserts, deletes, [], unchanged}", label: "[DIFF::[7]]")
         # [x] Implemented
         # This is only a layout change where items have been removed from the old menu
         # or added in the new menu.
@@ -139,7 +139,7 @@ defmodule ExSni.MenuDiff do
         {0, [], node}
 
       {_inserts, deletes, updates, _unchanged} ->
-        # IO.inspect("{inserts, deletes, updates, unchanged}", label: "[DIFF::[8]]")
+        IO.inspect("{inserts, deletes, updates, unchanged}", label: "[DIFF::[8]]")
         # [x] Implemented
         # There are mixed changes in our menus:
         #   inserts and/or deletes, updates but also unchanged items

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule ExSni.MixProject do
       app: :ex_sni,
       name: "ExSNI",
       source_url: @source_url,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
@@ -26,17 +26,20 @@ defmodule ExSni.MixProject do
   end
 
   defp elixirc_paths(:dev), do: ["lib", "examples"]
+  defp elixirc_paths(:test), do: ["lib", "examples", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
       {:ex_dbus, "~> 0.1.1"},
-      # {:ex_dbus, path: "../ex_dbus"},
       {:xdiff_plus, "~> 0.1"},
 
       # UUID generator
       {:uuid, "~> 1.1"},
+
+      # XML utility - ex_dbus already requires it
+      {:saxy, "~> 1.4.0"},
 
       # Development dialyzer
       {:dialyxir, "~> 1.1.0", only: [:dev, :test], runtime: false},

--- a/test/diff_test.ex
+++ b/test/diff_test.ex
@@ -1,0 +1,303 @@
+defmodule ExSni.MenuDiffTest do
+  use ExUnit.Case
+  alias ExSni.Menu.Item
+  alias ExSni.MenuDiff
+
+  @old_menu """
+  <root id="0" uuid="af245ccd-3eaf-4909-b8b6-2a7d1985450b" uid="" enabled="true" visible="true" label="" checked="false">
+    <item id="1" uuid="a4a47b70-eb07-424f-ab84-bdc712dce1ba" uid="" type="standard" enabled="true" visible="true" label="Open" checked="false"/>
+    <item id="2" uuid="81633cf4-233f-41a4-826f-daf2197aeea2" uid="" type="checkbox" enabled="true" visible="true" label="Pause Network" checked="false"/>
+    <item id="3" uuid="b09cb7f5-9fb0-45ed-8a2b-8402e7a16ad6" uid="" type="standard" enabled="false" visible="true" label="No Activity" checked="false"/>
+    <item id="4" uuid="928ec29a-2d7f-40ae-9c5b-b7c9696f9a0f" uid="" type="standard" enabled="true" visible="true" label="Quit" checked="false"/>
+    <item id="5" uuid="df1323b5-0ed0-4979-a758-36d3e939a363" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+    <menu id="6" uuid="94f22c24-6e2d-45d6-a0c3-9d2673d92e62" uid="" enabled="true" visible="true" label="DevTools - 10002000" checked="false">
+      <item id="7" uuid="d255e376-53bc-480f-a548-7372dd0b481d" uid="" type="standard" enabled="true" visible="true" label="Check for Update" checked="false"/>
+      <menu id="8" uuid="8cf0a39c-724d-4bbc-b11f-df3b5e439792" uid="" enabled="true" visible="true" label="View" checked="false">
+        <item id="9" uuid="d40511f3-1afb-430a-a247-c8b542867fda" uid="" type="standard" enabled="true" visible="true" label="Open Browser" checked="false"/>
+        <item id="10" uuid="7d8bc8c7-5440-4749-a8c1-8188bc2c2ab6" uid="" type="standard" enabled="true" visible="true" label="Show Default Layout" checked="false"/>
+        <item id="11" uuid="330403f4-a28a-46f1-a755-3aada9b59198" uid="" type="standard" enabled="true" visible="true" label="Show Android Layout" checked="false"/>
+        <item id="12" uuid="1b16c94a-f05c-4a43-8957-8e05ee96d3c3" uid="" type="standard" enabled="true" visible="true" label="Show iOS Layout" checked="false"/>
+      </menu>
+      <item id="13" uuid="efcdf7d7-3757-4a0f-adaf-b84faa25312b" uid="" type="standard" enabled="true" visible="true" label="Observer" checked="false"/>
+      <item id="14" uuid="3f571beb-13d3-4bdf-a0f9-c0706793333d" uid="" type="standard" enabled="true" visible="true" label="Login" checked="false"/>
+      <item id="15" uuid="9f51c7bf-9bbc-4b15-add3-921a25145523" uid="" type="standard" enabled="true" visible="true" label="Logout" checked="false"/>
+      <item id="16" uuid="0f2f28ef-98de-44e2-87e9-acef961558e7" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="17" uuid="bb3d172a-bda3-4834-9276-0a0e337a2f95" uid="" type="standard" enabled="true" visible="true" label="Restart" checked="false"/>
+    </menu>
+    <item id="18" uuid="372c06d9-2e98-4f24-ad4f-3f88e8bb95b9" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+    <item id="19" uuid="8fef8fca-35dd-41f6-a71d-c3a5f5ecd1ca" uid="" type="standard" enabled="true" visible="true" label="Zones" checked="false"/>
+    <menu id="20" uuid="683aaa93-2788-48a7-bc23-a8328b8ca634" uid="" enabled="true" visible="true" label="   10002000&apos;s zone" checked="false">
+      <item id="21" uuid="be736f4a-471d-4724-9363-29a459febe0c" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="22" uuid="952d7997-5381-4b03-9a8f-5cb656d686fb" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="23" uuid="7dfeb88b-f59d-4721-80c6-8a587b62bf95" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="24" uuid="5a4b76da-2c94-4804-b053-ec8084e125a7" uid="" type="standard" enabled="true" visible="true" label="0 of 0 Online" checked="false"/>
+      <item id="25" uuid="aa67ad1e-bcba-45ef-a80e-c76cb5cec1cd" uid="" type="standard" enabled="true" visible="true" label="38.68kb, 2 Files" checked="false"/>
+      <item id="26" uuid="4dbc1970-5467-44dd-9506-c7a55c767bdd" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="27" uuid="87fb2b86-3d5d-4e84-b053-9408c9744de4" uid="" type="standard" enabled="true" visible="true" label="Updated i4d18u02asy6qq69 2d ago" checked="false"/>
+      <item id="28" uuid="866b40e9-200f-4727-b53d-8c6e3cdb87a0" uid="" type="standard" enabled="false" visible="true" label="Deleted kqchvyjxi1yw70xc 2d ago" checked="false"/>
+      <item id="29" uuid="98091b81-5bd2-445a-9642-1845828b2f8b" uid="" type="standard" enabled="false" visible="true" label="Deleted wf88k4px4jstq5q1 2d ago" checked="false"/>
+      <item id="30" uuid="3aa61f1e-5ed8-41c2-88eb-6d6226a9c783" uid="" type="standard" enabled="true" visible="true" label="Updated image(2).png 2d ago" checked="false"/>
+    </menu>
+    <menu id="31" uuid="ece98a90-09c0-48dc-ac9f-2cbea468e482" uid="" enabled="true" visible="true" label="   10002001" checked="false">
+      <item id="32" uuid="65af4b03-a6a8-4ccf-934e-e010c93cb9d6" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="33" uuid="7fa15f54-2bc5-4d03-a601-337811c74fe2" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="34" uuid="c933bbf5-4f5a-4f8c-9412-0b8f8d3e00e2" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="35" uuid="172712d4-09b1-4ee1-9766-d33550712fb1" uid="" type="standard" enabled="true" visible="true" label="0 of 0 Online" checked="false"/>
+      <item id="36" uuid="c1f1c936-f965-451e-aa8a-5f56c7d28d1d" uid="" type="standard" enabled="true" visible="true" label="0 bytes, 0 Files" checked="false"/>
+    </menu>
+    <menu id="37" uuid="fcd8c780-98a4-4196-8718-518b08c92619" uid="" enabled="true" visible="true" label="   First" checked="false">
+      <item id="38" uuid="2cd74973-5f3b-4fd9-af4b-0b96809dc962" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="39" uuid="e7fbe885-b607-4c20-aaa8-ccc4f9df1135" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="40" uuid="0e30403d-8592-45fc-9239-69dbd5417ad7" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="41" uuid="0c785832-d68c-4611-864b-59c9e35a3e03" uid="" type="standard" enabled="true" visible="true" label="3 of 10 Online" checked="false"/>
+      <item id="42" uuid="ce8eb8d2-392c-4630-9007-93d92be23561" uid="" type="standard" enabled="true" visible="true" label="1.29gb, 79 Files" checked="false"/>
+      <item id="43" uuid="38780496-a250-4d37-b31d-8d03dea07889" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="44" uuid="b403d3f2-3c28-4903-b5ab-4021cb660c17" uid="" type="standard" enabled="true" visible="true" label="Downloaded dDrive-1.2.5-win32... 48d ago" checked="false"/>
+      <item id="45" uuid="eacad5d9-86a4-4be6-a5e4-09f7c8e3161f" uid="" type="standard" enabled="true" visible="true" label="Downloaded dDrive-1.0.1-win32... 163d ago" checked="false"/>
+      <item id="46" uuid="ef80251a-4687-4b5d-96d7-ae7d2bf0fe0e" uid="" type="standard" enabled="true" visible="true" label="Downloaded dDrive-1.2.1-win32... 168d ago" checked="false"/>
+      <item id="47" uuid="3bd19d46-b2fa-4bbe-b6b8-714fe814af20" uid="" type="standard" enabled="true" visible="true" label="Downloaded dDrive-1.3.5.dmg 2d ago" checked="false"/>
+      <item id="48" uuid="38f4d101-49d4-4068-8e8a-96f989b885cb" uid="" type="standard" enabled="true" visible="true" label="Downloaded nightly_debug.zip 2d ago" checked="false"/>
+    </menu>
+    <menu id="49" uuid="1785dd6d-141a-4ea2-a2cf-37e61c2a8014" uid="" enabled="true" visible="true" label="   Mikesnewzone2" checked="false">
+      <item id="50" uuid="4c795379-d80e-4e90-80f4-f963c3fcafea" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="51" uuid="1622028c-b702-4849-88e3-8e838890c1f4" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="52" uuid="93946707-cf87-4d0c-935f-8bf55055b69e" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="53" uuid="e719ab8e-55f6-4870-a924-c90435af4314" uid="" type="standard" enabled="true" visible="true" label="0 of 0 Online" checked="false"/>
+      <item id="54" uuid="6dea323b-c04a-4e2e-a4ca-96f1da84b2eb" uid="" type="standard" enabled="true" visible="true" label="0 bytes, 0 Files" checked="false"/>
+    </menu>
+  </root>
+  """
+
+  @new_menu """
+  <root id="0" uuid="12b4c399-d3b8-4eab-90cd-a0a7ebfb8953" uid="" enabled="true" visible="true" label="" checked="false">
+    <item id="0" uuid="b8062e81-f88a-4110-b628-8ffaf7d74c52" uid="" type="standard" enabled="true" visible="true" label="Open" checked="false"/>
+    <item id="0" uuid="f34a673b-bec6-433c-b424-8269afbce9fe" uid="" type="checkbox" enabled="true" visible="true" label="Pause Network" checked="false"/>
+    <item id="0" uuid="53aaff62-2821-4539-abf1-ef78e2c7df19" uid="" type="standard" enabled="false" visible="true" label="No Activity" checked="false"/>
+    <item id="0" uuid="4030b76e-aed5-4d90-87a3-11048adc763c" uid="" type="standard" enabled="true" visible="true" label="Quit" checked="false"/>
+    <item id="1" uuid="414c1187-da77-47c4-9018-d4332985bb99" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+    <menu id="0" uuid="f2b35806-743e-4742-ad18-4e1dbc45cb5f" uid="" enabled="true" visible="true" label="DevTools - 10002000" checked="false">
+      <item id="0" uuid="bf761e38-11e4-4492-bc7d-d59547d417ee" uid="" type="standard" enabled="true" visible="true" label="Check for Update" checked="false"/>
+      <menu id="0" uuid="17e68c4f-3bcd-4e76-b559-7b134e072e48" uid="" enabled="true" visible="true" label="View" checked="false">
+        <item id="0" uuid="4b88391f-3811-43d2-8e04-94dd82616bb8" uid="" type="standard" enabled="true" visible="true" label="Open Browser" checked="false"/>
+        <item id="0" uuid="39e40638-ef74-4b12-adf1-fad9173f8ff1" uid="" type="standard" enabled="true" visible="true" label="Show Default Layout" checked="false"/>
+        <item id="0" uuid="c3c8b494-8177-438e-b0dd-2c33597792a9" uid="" type="standard" enabled="true" visible="true" label="Show Android Layout" checked="false"/>
+        <item id="0" uuid="a30115d1-5d7c-4397-a7d0-d50ba300f658" uid="" type="standard" enabled="true" visible="true" label="Show iOS Layout" checked="false"/>
+      </menu>
+      <item id="0" uuid="49c15936-0a30-4fca-b4cb-d8e5351f3035" uid="" type="standard" enabled="true" visible="true" label="Observer" checked="false"/>
+      <item id="0" uuid="11b825ae-f0b9-4281-bb8b-35631a6b8345" uid="" type="standard" enabled="true" visible="true" label="Login" checked="false"/>
+      <item id="0" uuid="91d1e216-8c64-48fe-9c4e-10036b0c49bc" uid="" type="standard" enabled="true" visible="true" label="Logout" checked="false"/>
+      <item id="1" uuid="cbcad550-2f1c-4e1f-944d-4053830976d2" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="0" uuid="5d505dd1-8f8c-4690-86f7-de9432db6346" uid="" type="standard" enabled="true" visible="true" label="Restart" checked="false"/>
+    </menu>
+    <item id="1" uuid="646b5d12-14c9-4399-8f6b-089c3b96c7ae" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+    <item id="0" uuid="1cac10c5-d9ae-4663-8230-d3eec99afd06" uid="" type="standard" enabled="true" visible="true" label="Zones" checked="false"/>
+    <menu id="0" uuid="64da9bf4-3212-40c1-8899-3d7308f4f940" uid="" enabled="true" visible="true" label="   10002000&apos;s zone" checked="false">
+      <item id="0" uuid="eed87c90-9a11-4222-985e-fd37b9b1f3c7" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="0" uuid="f11fcb4c-2e5f-46cc-b756-7b3c09cb0e43" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="1" uuid="f71445d0-140f-499f-8c1c-b522b3f3f87d" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="0" uuid="2da0e225-cbd6-4415-9500-fe8829581cd2" uid="" type="standard" enabled="true" visible="true" label="0 of 0 Online" checked="false"/>
+      <item id="0" uuid="d27396d9-5837-45dc-a92d-a2e4a385776c" uid="" type="standard" enabled="true" visible="true" label="38.68kb, 2 Files" checked="false"/>
+      <item id="1" uuid="6568ce65-baca-4c19-b801-b634defbfcae" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="0" uuid="bd5a64a3-a2b0-4ae5-bc62-5f3ecbd8d5a0" uid="" type="standard" enabled="true" visible="true" label="Updated i4d18u02asy6qq69 2d ago" checked="false"/>
+      <item id="0" uuid="d01881b0-e9db-42d0-a542-e5bd27364c77" uid="" type="standard" enabled="false" visible="true" label="Deleted kqchvyjxi1yw70xc 2d ago" checked="false"/>
+      <item id="0" uuid="61c3e243-4199-466b-b787-368774a75922" uid="" type="standard" enabled="false" visible="true" label="Deleted wf88k4px4jstq5q1 2d ago" checked="false"/>
+      <item id="0" uuid="b0c6c7bc-b144-41f5-a3a9-2b28aa33809f" uid="" type="standard" enabled="true" visible="true" label="Updated image(2).png 2d ago" checked="false"/>
+    </menu>
+    <menu id="0" uuid="0edeb04b-c10f-4cb7-946c-acda1d73396d" uid="" enabled="true" visible="true" label="   10002001" checked="false">
+      <item id="0" uuid="9bcd3fc0-c8b0-44a9-a565-f2a2fbe612ef" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="0" uuid="89cd95c8-1828-45a6-b305-bbbad03858f7" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="1" uuid="08530d49-2e86-4c44-b8f3-732be1a3ec68" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="0" uuid="c7e860a7-d080-462d-852e-0b5423cf1166" uid="" type="standard" enabled="true" visible="true" label="0 of 0 Online" checked="false"/>
+      <item id="0" uuid="8a85fc0b-8e82-474f-a549-97be09135743" uid="" type="standard" enabled="true" visible="true" label="0 bytes, 0 Files" checked="false"/>
+    </menu>
+    <menu id="0" uuid="89b127c9-4e14-4df5-aebe-99bdb4b2153e" uid="" enabled="true" visible="true" label="   First" checked="false">
+      <item id="0" uuid="1dd838f3-2650-4ec3-b11e-8012c0b28c01" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="0" uuid="321fbcbb-3a74-40df-b6b9-a97567a2c0d0" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="1" uuid="89c4e171-7398-42e9-bdd2-7994e433c370" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="0" uuid="1f5020a0-94e4-43ea-b871-8b7c209bd105" uid="" type="standard" enabled="true" visible="true" label="3 of 10 Online" checked="false"/>
+      <item id="0" uuid="143fc175-c9ba-44d1-a28a-ede30c0c26f7" uid="" type="standard" enabled="true" visible="true" label="1.29gb, 79 Files" checked="false"/>
+      <item id="1" uuid="554b785e-8598-44c9-9877-e26c36693cf0" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="0" uuid="d878eea1-67c2-4ef4-8362-200ed5865d46" uid="" type="standard" enabled="true" visible="true" label="Downloaded dDrive-1.2.5-win32... 48d ago" checked="false"/>
+      <item id="0" uuid="04b62445-dd52-4534-afd8-b5a634cc3653" uid="" type="standard" enabled="true" visible="true" label="Downloaded dDrive-1.0.1-win32... 163d ago" checked="false"/>
+      <item id="0" uuid="19696f9d-56c3-4265-bfc3-92646e608083" uid="" type="standard" enabled="true" visible="true" label="Downloaded dDrive-1.2.1-win32... 168d ago" checked="false"/>
+      <item id="0" uuid="69580606-751f-4e46-85f7-3f36e4d022c5" uid="" type="standard" enabled="true" visible="true" label="Downloaded dDrive-1.3.5.dmg 2d ago" checked="false"/>
+      <item id="0" uuid="7bf9df33-4276-4096-8b52-9d8e803bf3c8" uid="" type="standard" enabled="true" visible="true" label="Downloaded nightly_debug.zip 2d ago" checked="false"/>
+    </menu>
+    <menu id="0" uuid="a1a26acd-da46-47ca-96b1-83c9916a1bab" uid="" enabled="true" visible="true" label="   Mikesnewzone2" checked="false">
+      <item id="0" uuid="4ca38b59-3c6a-4b55-abf3-17bcd6815e85" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="0" uuid="11fe674a-3933-47b8-bdce-03c10d181b1b" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="1" uuid="2cc7109e-4a99-45a2-bfc1-5a5f113a4ddc" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="0" uuid="09971ed7-d335-4e5f-a9ab-eaea7ad33513" uid="" type="standard" enabled="true" visible="true" label="0 of 0 Online" checked="false"/>
+      <item id="0" uuid="d6d6b790-f88c-494b-8d2c-5fa508a9e5c2" uid="" type="standard" enabled="true" visible="true" label="0 bytes, 0 Files" checked="false"/>
+    </menu>
+    <menu id="0" uuid="1058dc80-e409-4e3b-8923-1567346e674b" uid="" enabled="true" visible="true" label="   Mikesnewzone1" checked="false">
+      <item id="0" uuid="eb7943a0-c7c4-483b-acbb-6936c07790c5" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="0" uuid="537af5b7-9681-4449-a418-f99df0d79d55" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="1" uuid="a6330dee-ac2d-4eb9-a69d-f2df6d2c8a76" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="0" uuid="42099a3c-0a9c-4ed0-8454-00dc75abda86" uid="" type="standard" enabled="true" visible="true" label="0 of 0 Online" checked="false"/>
+      <item id="0" uuid="2237dfd7-22cc-4861-a46d-da93a1824587" uid="" type="standard" enabled="true" visible="true" label="0 bytes, 0 Files" checked="false"/>
+    </menu>
+  </root>
+  """
+
+  @next_menu """
+  <root id="0" uuid="12b4c399-d3b8-4eab-90cd-a0a7ebfb8953" uid="" enabled="true" visible="true" label="" checked="false">
+    <item id="1" uuid="b8062e81-f88a-4110-b628-8ffaf7d74c52" uid="" type="standard" enabled="true" visible="true" label="Open" checked="false"/>
+    <item id="2" uuid="f34a673b-bec6-433c-b424-8269afbce9fe" uid="" type="checkbox" enabled="true" visible="true" label="Pause Network" checked="false"/>
+    <item id="3" uuid="53aaff62-2821-4539-abf1-ef78e2c7df19" uid="" type="standard" enabled="false" visible="true" label="No Activity" checked="false"/>
+    <item id="4" uuid="4030b76e-aed5-4d90-87a3-11048adc763c" uid="" type="standard" enabled="true" visible="true" label="Quit" checked="false"/>
+    <item id="5" uuid="414c1187-da77-47c4-9018-d4332985bb99" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+    <menu id="6" uuid="f2b35806-743e-4742-ad18-4e1dbc45cb5f" uid="" enabled="true" visible="true" label="DevTools - 10002000" checked="false">
+      <item id="7" uuid="bf761e38-11e4-4492-bc7d-d59547d417ee" uid="" type="standard" enabled="true" visible="true" label="Check for Update" checked="false"/>
+      <menu id="8" uuid="17e68c4f-3bcd-4e76-b559-7b134e072e48" uid="" enabled="true" visible="true" label="View" checked="false">
+        <item id="9" uuid="4b88391f-3811-43d2-8e04-94dd82616bb8" uid="" type="standard" enabled="true" visible="true" label="Open Browser" checked="false"/>
+        <item id="10" uuid="39e40638-ef74-4b12-adf1-fad9173f8ff1" uid="" type="standard" enabled="true" visible="true" label="Show Default Layout" checked="false"/>
+        <item id="11" uuid="c3c8b494-8177-438e-b0dd-2c33597792a9" uid="" type="standard" enabled="true" visible="true" label="Show Android Layout" checked="false"/>
+        <item id="12" uuid="a30115d1-5d7c-4397-a7d0-d50ba300f658" uid="" type="standard" enabled="true" visible="true" label="Show iOS Layout" checked="false"/>
+      </menu>
+      <item id="13" uuid="49c15936-0a30-4fca-b4cb-d8e5351f3035" uid="" type="standard" enabled="true" visible="true" label="Observer" checked="false"/>
+      <item id="14" uuid="11b825ae-f0b9-4281-bb8b-35631a6b8345" uid="" type="standard" enabled="true" visible="true" label="Login" checked="false"/>
+      <item id="15" uuid="91d1e216-8c64-48fe-9c4e-10036b0c49bc" uid="" type="standard" enabled="true" visible="true" label="Logout" checked="false"/>
+      <item id="16" uuid="cbcad550-2f1c-4e1f-944d-4053830976d2" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="17" uuid="5d505dd1-8f8c-4690-86f7-de9432db6346" uid="" type="standard" enabled="true" visible="true" label="Restart" checked="false"/>
+    </menu>
+    <item id="18" uuid="646b5d12-14c9-4399-8f6b-089c3b96c7ae" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+    <item id="19" uuid="1cac10c5-d9ae-4663-8230-d3eec99afd06" uid="" type="standard" enabled="true" visible="true" label="Zones" checked="false"/>
+    <menu id="20" uuid="64da9bf4-3212-40c1-8899-3d7308f4f940" uid="" enabled="true" visible="true" label="   10002000&apos;s zone" checked="false">
+      <item id="21" uuid="eed87c90-9a11-4222-985e-fd37b9b1f3c7" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="22" uuid="f11fcb4c-2e5f-46cc-b756-7b3c09cb0e43" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="23" uuid="f71445d0-140f-499f-8c1c-b522b3f3f87d" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="24" uuid="2da0e225-cbd6-4415-9500-fe8829581cd2" uid="" type="standard" enabled="true" visible="true" label="0 of 0 Online" checked="false"/>
+      <item id="25" uuid="d27396d9-5837-45dc-a92d-a2e4a385776c" uid="" type="standard" enabled="true" visible="true" label="38.68kb, 2 Files" checked="false"/>
+      <item id="26" uuid="6568ce65-baca-4c19-b801-b634defbfcae" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="27" uuid="bd5a64a3-a2b0-4ae5-bc62-5f3ecbd8d5a0" uid="" type="standard" enabled="true" visible="true" label="Updated i4d18u02asy6qq69 2d ago" checked="false"/>
+      <item id="28" uuid="d01881b0-e9db-42d0-a542-e5bd27364c77" uid="" type="standard" enabled="false" visible="true" label="Deleted kqchvyjxi1yw70xc 2d ago" checked="false"/>
+      <item id="29" uuid="61c3e243-4199-466b-b787-368774a75922" uid="" type="standard" enabled="false" visible="true" label="Deleted wf88k4px4jstq5q1 2d ago" checked="false"/>
+      <item id="30" uuid="b0c6c7bc-b144-41f5-a3a9-2b28aa33809f" uid="" type="standard" enabled="true" visible="true" label="Updated image(2).png 2d ago" checked="false"/>
+    </menu>
+    <menu id="31" uuid="0edeb04b-c10f-4cb7-946c-acda1d73396d" uid="" enabled="true" visible="true" label="   10002001" checked="false">
+      <item id="32" uuid="9bcd3fc0-c8b0-44a9-a565-f2a2fbe612ef" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="33" uuid="89cd95c8-1828-45a6-b305-bbbad03858f7" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="34" uuid="08530d49-2e86-4c44-b8f3-732be1a3ec68" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="35" uuid="c7e860a7-d080-462d-852e-0b5423cf1166" uid="" type="standard" enabled="true" visible="true" label="0 of 0 Online" checked="false"/>
+      <item id="36" uuid="8a85fc0b-8e82-474f-a549-97be09135743" uid="" type="standard" enabled="true" visible="true" label="0 bytes, 0 Files" checked="false"/>
+    </menu>
+    <menu id="37" uuid="89b127c9-4e14-4df5-aebe-99bdb4b2153e" uid="" enabled="true" visible="true" label="   First" checked="false">
+      <item id="38" uuid="1dd838f3-2650-4ec3-b11e-8012c0b28c01" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="39" uuid="321fbcbb-3a74-40df-b6b9-a97567a2c0d0" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="40" uuid="89c4e171-7398-42e9-bdd2-7994e433c370" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="41" uuid="1f5020a0-94e4-43ea-b871-8b7c209bd105" uid="" type="standard" enabled="true" visible="true" label="3 of 10 Online" checked="false"/>
+      <item id="42" uuid="143fc175-c9ba-44d1-a28a-ede30c0c26f7" uid="" type="standard" enabled="true" visible="true" label="1.29gb, 79 Files" checked="false"/>
+      <item id="43" uuid="554b785e-8598-44c9-9877-e26c36693cf0" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="44" uuid="d878eea1-67c2-4ef4-8362-200ed5865d46" uid="" type="standard" enabled="true" visible="true" label="Downloaded dDrive-1.2.5-win32... 48d ago" checked="false"/>
+      <item id="45" uuid="04b62445-dd52-4534-afd8-b5a634cc3653" uid="" type="standard" enabled="true" visible="true" label="Downloaded dDrive-1.0.1-win32... 163d ago" checked="false"/>
+      <item id="46" uuid="19696f9d-56c3-4265-bfc3-92646e608083" uid="" type="standard" enabled="true" visible="true" label="Downloaded dDrive-1.2.1-win32... 168d ago" checked="false"/>
+      <item id="47" uuid="69580606-751f-4e46-85f7-3f36e4d022c5" uid="" type="standard" enabled="true" visible="true" label="Downloaded dDrive-1.3.5.dmg 2d ago" checked="false"/>
+      <item id="48" uuid="7bf9df33-4276-4096-8b52-9d8e803bf3c8" uid="" type="standard" enabled="true" visible="true" label="Downloaded nightly_debug.zip 2d ago" checked="false"/>
+    </menu>
+    <menu id="49" uuid="a1a26acd-da46-47ca-96b1-83c9916a1bab" uid="" enabled="true" visible="true" label="   Mikesnewzone2" checked="false">
+      <item id="50" uuid="4ca38b59-3c6a-4b55-abf3-17bcd6815e85" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="51" uuid="11fe674a-3933-47b8-bdce-03c10d181b1b" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="52" uuid="2cc7109e-4a99-45a2-bfc1-5a5f113a4ddc" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="53" uuid="09971ed7-d335-4e5f-a9ab-eaea7ad33513" uid="" type="standard" enabled="true" visible="true" label="0 of 0 Online" checked="false"/>
+      <item id="54" uuid="d6d6b790-f88c-494b-8d2c-5fa508a9e5c2" uid="" type="standard" enabled="true" visible="true" label="0 bytes, 0 Files" checked="false"/>
+    </menu>
+    <menu id="55" uuid="1058dc80-e409-4e3b-8923-1567346e674b" uid="" enabled="true" visible="true" label="   Mikesnewzone1" checked="false">
+      <item id="56" uuid="eb7943a0-c7c4-483b-acbb-6936c07790c5" uid="" type="standard" enabled="true" visible="true" label="Open Folder" checked="false"/>
+      <item id="57" uuid="537af5b7-9681-4449-a418-f99df0d79d55" uid="" type="standard" enabled="true" visible="true" label="Manage" checked="false"/>
+      <item id="58" uuid="a6330dee-ac2d-4eb9-a69d-f2df6d2c8a76" uid="" type="separator" enabled="true" visible="true" label="" checked="false"/>
+      <item id="59" uuid="42099a3c-0a9c-4ed0-8454-00dc75abda86" uid="" type="standard" enabled="true" visible="true" label="0 of 0 Online" checked="false"/>
+      <item id="60" uuid="2237dfd7-22cc-4861-a46d-da93a1824587" uid="" type="standard" enabled="true" visible="true" label="0 bytes, 0 Files" checked="false"/>
+    </menu>
+  </root>
+  """
+
+  setup do
+    old_root = build_root(@old_menu)
+    new_root = build_root(@new_menu)
+    {:ok, %{old_root: old_root, new_root: new_root}}
+  end
+
+  test "something", %{old_root: old_root, new_root: new_root} do
+    {layout, updates, root} = MenuDiff.diff(new_root, old_root)
+
+    assert layout == 0
+    assert updates == []
+    assert String.replace(@old_menu, ~r/\n\s*/, "") == ExSni.XML.Builder.encode!(old_root)
+    assert String.replace(@new_menu, ~r/\n\s*/, "") == ExSni.XML.Builder.encode!(new_root)
+    assert String.replace(@next_menu, ~r/\n\s*/, "") == ExSni.XML.Builder.encode!(root)
+  end
+
+  defp build_root(source) do
+    case Saxy.SimpleForm.parse_string(source) do
+      {:ok, {"root", attrs, children}} ->
+        uuid_value =
+          case Enum.find(attrs, fn {key, _} -> key == "uuid" end) do
+            {_, value} -> value
+            _ -> ""
+          end
+
+        children = build_nodes(children) |> Enum.reject(fn node -> node == nil end)
+        %Item{type: :root, uuid: uuid_value, children: children}
+
+      _ ->
+        nil
+    end
+  end
+
+  defp build_nodes([]) do
+    []
+  end
+
+  defp build_nodes([child | children]) do
+    [build_node(child) | build_nodes(children)]
+  end
+
+  defp build_node({"menu", attrs, children}) do
+    children = build_nodes(children) |> Enum.reject(fn node -> node == nil end)
+    node = %Item{type: :menu, children: children}
+
+    Enum.reduce(attrs, node, fn {name, value}, node ->
+      set_attr(node, name, value)
+    end)
+  end
+
+  defp build_node({"item", attrs, children}) do
+    children = build_nodes(children) |> Enum.reject(fn node -> node == nil end)
+    {_, value} = Enum.find(attrs, fn {key, _} -> key == "type" end)
+    node = %Item{type: String.to_atom(value), children: children}
+
+    Enum.reduce(attrs, node, fn {name, value}, node ->
+      set_attr(node, name, value)
+    end)
+  end
+
+  defp build_node(_) do
+    nil
+  end
+
+  defp set_attr(node, "type", value) do
+    Map.put(node, :type, String.to_atom(value))
+  end
+
+  defp set_attr(node, name, "true") do
+    Map.put(node, String.to_atom(name), true)
+  end
+
+  defp set_attr(node, name, "false") do
+    Map.put(node, String.to_atom(name), false)
+  end
+
+  defp set_attr(node, "id", value) do
+    {id_value, _} = Integer.parse(value)
+    Map.put(node, :id, id_value)
+  end
+
+  defp set_attr(node, name, value) when name in ["label", "uuid"] do
+    Map.put(node, String.to_atom(name), value)
+  end
+
+  defp set_attr(node, _, _) do
+    node
+  end
+end

--- a/test/support/menu_item_protocols.ex
+++ b/test/support/menu_item_protocols.ex
@@ -1,0 +1,97 @@
+defimpl ExSni.XML.Builder, for: ExSni.Menu.Item do
+  def encode!(item) do
+    Saxy.Builder.build(item)
+    |> Saxy.encode!()
+  end
+end
+
+defimpl ExSni.XML.Builder, for: ExSni.Menu do
+  def encode!(menu) do
+    Saxy.Builder.build(menu)
+    |> Saxy.encode!()
+  end
+end
+
+defimpl ExSni.XML.Builder, for: Atom do
+  def encode!(atom) do
+    Atom.to_string(atom)
+  end
+end
+
+defimpl ExSni.XML.Builder, for: String do
+  def encode!(string) do
+    string
+  end
+end
+
+defimpl ExSni.XML.Builder, for: List do
+  def encode!(list) do
+    Enum.map(list, &ExSni.XML.Builder.encode!/1)
+    |> Enum.join("")
+  end
+end
+
+defimpl ExSni.XML.Builder, for: Integer do
+  def encode!(number) do
+    "#{number}"
+  end
+end
+
+defimpl ExSni.XML.Builder, for: Tuple do
+  def encode!({a, b}) do
+    ExSni.XML.Builder.encode!([a, b])
+  end
+
+  def encode!({a, b, c}) do
+    ExSni.XML.Builder.encode!([a, b, c])
+  end
+
+  def encode!({a, b, c, d}) do
+    ExSni.XML.Builder.encode!([a, b, c, d])
+  end
+end
+
+defimpl ExSni.XML.Builder, for: Any do
+  def encode!(value) do
+    "#{inspect(value)}"
+  end
+end
+
+defimpl Saxy.Builder, for: ExSni.Menu do
+  import Saxy.XML
+
+  def build(%{version: version, root: root}) do
+    element("dbus_menu", [version: version], [Saxy.Builder.build(root)])
+  end
+end
+
+defimpl Saxy.Builder, for: ExSni.Menu.Item do
+  import Saxy.XML
+
+  def build(%{type: :root, children: children} = item) do
+    element("root", build_attrs(item), Enum.map(children, &build/1))
+  end
+
+  def build(%{type: :menu, children: children} = item) do
+    element("menu", build_attrs(item), Enum.map(children, &build/1))
+  end
+
+  def build(%{children: children} = item) do
+    element("item", build_item_attrs(item), Enum.map(children, &build/1))
+  end
+
+  defp build_item_attrs(item) when is_map(item) do
+    [:id, :uuid, :uid, :type, :enabled, :visible, :label, :checked]
+    |> build_attrs(item)
+  end
+
+  defp build_attrs(item) when is_map(item) do
+    [:id, :uuid, :uid, :enabled, :visible, :label, :checked]
+    |> build_attrs(item)
+  end
+
+  defp build_attrs(attrs, item) when is_list(attrs) do
+    attrs
+    |> Enum.map(fn attr -> {attr, Map.get(item, attr)} end)
+  end
+end

--- a/test/support/xml_builder.ex
+++ b/test/support/xml_builder.ex
@@ -1,0 +1,4 @@
+defprotocol ExSni.XML.Builder do
+  @fallback_to_any true
+  def encode!(t)
+end


### PR DESCRIPTION
Due to a bug in incrementing dbus menu IDs, some older IDs were reused when updating the menu, resulting in broken labels