### PR TITLE
Handle menu server crash

### DIFF
--- a/lib/ex_sni.ex
+++ b/lib/ex_sni.ex
@@ -116,7 +116,7 @@ defmodule ExSni do
   @spec update_menu(
           sni_pid :: GenServer.server(),
           parentId :: nil | integer(),
-          menu :: nil | %Menu{}
+          menu :: nil | Menu.t()
         ) :: any()
   def update_menu(sni_pid, nil, menu) do
     set_menu(sni_pid, menu)
@@ -143,7 +143,7 @@ defmodule ExSni do
     end
   end
 
-  @spec update_icon(sni_pid :: GenServer.server(), icon :: nil | %Icon{}) :: any()
+  @spec update_icon(sni_pid :: GenServer.server(), icon :: nil | Icon.t()) :: any()
   def update_icon(sni_pid, icon) do
     with {:ok, icon} <- set_icon(sni_pid, icon) do
       send_icon_signal(sni_pid, "NewIcon")

--- a/lib/menu.ex
+++ b/lib/menu.ex
@@ -212,10 +212,19 @@ defmodule ExSni.Menu do
 
   defp get_callbacks(callbacks, eventId) do
     callbacks
-    |> Enum.filter(&is_tuple/1)
-    |> Enum.filter(&(elem(&1, 0) == eventId))
+    # |> Enum.filter(&is_tuple/1)
+    # |> Enum.filter(&(elem(&1, 0) == eventId))
+    |> Enum.filter(&has_event_id(&1, eventId))
     |> Enum.map(&elem(&1, 1))
     |> Enum.filter(&is_function(&1))
+  end
+
+  defp has_event_id(item, eventId) when is_tuple(item) do
+    elem(item, 0) == eventId
+  end
+
+  defp has_event_id(_, _) do
+    false
   end
 
   @spec find_child(list(Item.t()), non_neg_integer()) :: nil | Item.t()

--- a/lib/menu/backup_store.ex
+++ b/lib/menu/backup_store.ex
@@ -1,0 +1,48 @@
+defmodule ExSni.Menu.BackupStore do
+  use GenServer
+
+  def start_link(opts, gen_opts \\ []) do
+    GenServer.start_link(
+      __MODULE__,
+      opts,
+      gen_opts
+    )
+  end
+
+  @impl true
+  def init(options) do
+    {:ok, Keyword.get(options, :menu, nil)}
+  end
+
+  @impl true
+  def handle_call({:restore_menu, menu}, {pid, _tag}, nil)
+      when is_pid(pid) do
+    Process.monitor(pid)
+
+    {:reply, menu, menu}
+  end
+
+  def handle_call({:restore_menu, _menu}, {pid, _tag}, menu) do
+    Process.monitor(pid)
+    {:reply, menu, menu}
+  end
+
+  def handle_call({:save_menu, menu}, {_pid, _tag} = _from, _menu) do
+    {:reply, menu, menu}
+  end
+
+  @impl true
+  def handle_cast({:save_menu, menu}, _menu) do
+    {:noreply, menu}
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _object, _reason}, menu) do
+    Process.demonitor(ref)
+    {:noreply, menu}
+  end
+
+  def handle_info(_, state) do
+    {:noreply, state}
+  end
+end

--- a/lib/menu/backup_store.ex
+++ b/lib/menu/backup_store.ex
@@ -1,4 +1,8 @@
 defmodule ExSni.Menu.BackupStore do
+  @moduledoc """
+  A GenServer that stores the menu for Menu.Server
+  and allows Menu.Server to retrieve it on init/restart
+  """
   use GenServer
 
   def start_link(opts, gen_opts \\ []) do

--- a/lib/menu/server.ex
+++ b/lib/menu/server.ex
@@ -247,7 +247,7 @@ defmodule ExSni.Menu.Server do
     case menu_diff do
       {-1, [], _} ->
         # No changes between the menus.
-        menu = %{new_menu | version: old_version}
+        menu = %{new_menu | version: old_version, root: old_root}
 
         # Return that there's no update, and clear the queue.
         {:skip,

--- a/lib/menu/server.ex
+++ b/lib/menu/server.ex
@@ -22,6 +22,7 @@ defmodule ExSni.Menu.Server do
 
   defmodule State do
     defstruct menu: %Menu{version: 1},
+              backup_server: nil,
               menu_update_timer: nil,
               last_update_at: 0,
               get_layout: {0, nil},
@@ -37,6 +38,7 @@ defmodule ExSni.Menu.Server do
             {last_requested_timestamp :: non_neg_integer(), payload :: any()}
     @type t() :: %__MODULE__{
             menu: Menu.t(),
+            backup_server: nil | GenServer.server(),
             last_update_at: non_neg_integer(),
             menu_update_timer: nil | reference(),
             get_layout: method_tracking(),
@@ -60,17 +62,22 @@ defmodule ExSni.Menu.Server do
 
   @impl true
   def init(options) do
+    backup_server = Keyword.get(options, :backup_server)
+
     init_menu =
       case Keyword.get(options, :menu, nil) do
         %Menu{} = menu -> menu
         _ -> %Menu{version: 1}
       end
 
-    state = %State{
-      menu: init_menu,
-      dbus_service: Keyword.get(options, :dbus_service, nil),
-      started_at: time()
-    }
+    state =
+      %State{
+        menu: init_menu,
+        dbus_service: Keyword.get(options, :dbus_service, nil),
+        started_at: time(),
+        backup_server: backup_server
+      }
+      |> restore_backup_menu()
 
     {:ok, state}
   end
@@ -679,7 +686,34 @@ defmodule ExSni.Menu.Server do
   end
 
   defp set_current_menu(state, menu) do
-    %{state | menu: menu}
+    backup_current_menu(%{state | menu: menu})
+  end
+
+  defp restore_backup_menu(%{backup_server: nil} = state) do
+    state
+  end
+
+  defp restore_backup_menu(%{backup_server: server, menu: init_menu} = state) do
+    try do
+      menu = GenServer.call(server, {:restore_menu, init_menu})
+      %{state | menu: menu}
+    rescue
+      _error -> state
+    end
+  end
+
+  defp backup_current_menu(%{backup_server: nil} = state) do
+    state
+  end
+
+  defp backup_current_menu(%{backup_server: server, menu: menu} = state) do
+    try do
+      GenServer.cast(server, {:save_menu, menu})
+    rescue
+      _ -> :ok
+    end
+
+    state
   end
 
   defp set_menu_queue(state, queue) do

--- a/lib/menu/server.ex
+++ b/lib/menu/server.ex
@@ -312,7 +312,7 @@ defmodule ExSni.Menu.Server do
     now = time(state)
 
     timeout =
-      if now >= throttle + 10 do
+      if now >= throttle do
         10
       else
         throttle - now
@@ -328,7 +328,7 @@ defmodule ExSni.Menu.Server do
     now = time(state)
 
     timeout =
-      if now >= throttle + last_update_at + 10 do
+      if now >= throttle + last_update_at do
         10
       else
         last_update_at + throttle - now

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule ExSni.MixProject do
       app: :ex_sni,
       name: "ExSNI",
       source_url: @source_url,
-      version: "0.2.4",
+      version: "0.2.5",
       elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/menu_item_protocols.ex
+++ b/test/support/menu_item_protocols.ex
@@ -26,8 +26,9 @@ end
 
 defimpl ExSni.XML.Builder, for: List do
   def encode!(list) do
-    Enum.map(list, &ExSni.XML.Builder.encode!/1)
-    |> Enum.join("")
+    # Enum.map(list, &ExSni.XML.Builder.encode!/1)
+    # |> Enum.join("")
+    Enum.map_join(list, "", &ExSni.XML.Builder.encode!/1)
   end
 end
 


### PR DESCRIPTION
Fixes:
- Lost D-Bus menu IDs when no changes between old root and new root
- Prevents negative timeout values that would crash the Menu.Server 
- Credo warnings

Additions:
- Adds a storage GenServer to retrieve menus on Menu.Server crash, to partially re-sync D-Bus menus and Menu.Server menus