### PR TITLE
Override dbus cookie

### DIFF
--- a/lib/ex_sni.ex
+++ b/lib/ex_sni.ex
@@ -78,9 +78,33 @@ defmodule ExSni do
   @spec is_supported?(GenServer.server()) :: boolean()
   def is_supported?(sni_pid) do
     case get_bus(sni_pid) do
-      nil -> {:error, "Service has no DBUS connection"}
+      nil -> false
       bus_pid when is_pid(bus_pid) -> Bus.is_supported?(bus_pid)
-      error -> error
+      _ -> false
+    end
+  end
+
+  @doc """
+  Returns {:ok, sni_pid} if there is a StatusNotifierWatcher available
+  on the Session Bus. Returns {:error, reason} otherwise.
+  - sni_pid - The pid of the ExSni Supervisor
+  """
+  @spec get_supported(GenServer.server()) ::
+          {:ok, bus_pid :: GenServer.server()} | {:error, reason :: binary()}
+  def get_supported(sni_pid) do
+    case get_bus(sni_pid) do
+      nil ->
+        {:error, "Service has no DBUS connection"}
+
+      bus_pid when is_pid(bus_pid) ->
+        if Bus.is_supported?(bus_pid) do
+          {:ok, bus_pid}
+        else
+          {:error, "Unable to connect to StatusNotifierWatcher over D-Bus"}
+        end
+
+      error ->
+        error
     end
   end
 

--- a/lib/ex_sni.ex
+++ b/lib/ex_sni.ex
@@ -29,7 +29,7 @@ defmodule ExSni do
           start:
             {ExDBus.Service, :start_link,
              [
-               [name: service_name, schema: ExSni.Schema, router: router],
+               [name: service_name, schema: ExSni.Schema, router: router, cookie: :system_user],
                [name: dbus_service_pid]
              ]},
           restart: :transient

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule ExSni.MixProject do
       app: :ex_sni,
       name: "ExSNI",
       source_url: @source_url,
-      version: "0.2.7",
+      version: "0.2.8",
       elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Requires ex_dbus v0.1.4
Set `:cookie` to `:system_user` so that ex_dbus retrieves the current user UID to use in `EXTERNAL` auth over D-Bus.
See https://github.com/mpotra/ex_dbus/pull/2/ for details

L.E. reverted bug introduced in https://github.com/elixir-desktop/ex_sni/commit/e50b5e73c63e37733fd1dd639baabde99cf88daa